### PR TITLE
security fix: bump pg to 6.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "debug": "2.2.0",
     "@sailshq/lodash": "^3.10.2",
     "machine": "^15.0.0-21",
-    "pg": "6.1.0",
+    "pg": "6.1.6",
     "waterline-sql-builder": "^1.0.0-6"
   },
   "devDependencies": {


### PR DESCRIPTION
See
https://snyk.io/vuln/npm:pg:20170813
https://node-postgres.com/announcements#2017-08-12-code-execution-vulnerability

Seems like a pretty safe bump. I tried this new version out on my own sails app and all the tests still pass.