### PR TITLE
Fix: clean up getConnection() test properly

### DIFF
--- a/test/integration/connectable/get-connection.js
+++ b/test/integration/connectable/get-connection.js
@@ -24,6 +24,10 @@ describe('Connectable ::', function() {
       });
     });
 
+    after(function(done) {
+      manager.pool.end(done);
+    });
+
     it('should successfully return a PG Client instance', function(done) {
       Pack.getConnection({
         manager: manager
@@ -39,8 +43,9 @@ describe('Connectable ::', function() {
         // Assert that a PG Client is returned
         assert(report.connection instanceof pg.Client);
 
-        // Assert that the connection has a release function
-        assert(report.connection.release);
+        // Assert that the connection has a release function, and call it to
+        // release the connection.
+        report.connection.release();
 
         return done();
       });

--- a/test/integration/connectable/get-connection.js
+++ b/test/integration/connectable/get-connection.js
@@ -42,10 +42,7 @@ describe('Connectable ::', function() {
 
         // Assert that a PG Client is returned
         assert(report.connection instanceof pg.Client);
-
-        // Assert that the connection has a release function, and call it to
-        // release the connection.
-        report.connection.release();
+        assert('function' === typeof report.connection.release);
 
         return done();
       });


### PR DESCRIPTION
This fix for https://github.com/balderdashy/sails/issues/6908 will allow `mocha` to be updated to the latest version.